### PR TITLE
Add the '@' character to the regex of absolutify

### DIFF
--- a/src/quibble.coffee
+++ b/src/quibble.coffee
@@ -43,7 +43,7 @@ quibble.reset = (hard = false) ->
     ignoredCallerFiles = []
 
 quibble.absolutify = (relativePath, parentFileName = hackErrorStackToGetCallerFile()) ->
-  return relativePath if _.startsWith(relativePath, '/') || /^\w/.test(relativePath)
+  return relativePath if _.startsWith(relativePath, '/') || /^(\w|@)/.test(relativePath)
   path.resolve(path.dirname(parentFileName), relativePath)
 
 # private


### PR DESCRIPTION
Currently quibble considers as absolute paths, the ones that start with '/' or a word character (\w), but not the '@' character, which is the starting character for scoped modules.

eg: @organization/awesome-module