### PR TITLE
Drop undefined paths when looking for caller file

### DIFF
--- a/src/quibble.coffee
+++ b/src/quibble.coffee
@@ -76,7 +76,7 @@ hackErrorStackToGetCallerFile = (includeGlobalIgnores = true) ->
   e = new Error()
   currentFile = e.stack[0].getFileName()
   callerFile = _(e.stack).invoke('getFileName').
-    reject((f) -> includeGlobalIgnores && _.include(ignoredCallerFiles, f)).
+    reject((f) -> !f || (includeGlobalIgnores && _.include(ignoredCallerFiles, f))).
     select(path.isAbsolute).
     find((f) -> f != currentFile)
   Error.prepareStackTrace = originalFunc


### PR DESCRIPTION
After using `testdouble.replace(modulePath, ...)`, sometimes I get the following error: [TypeError: Path must be a string. Received undefined].

I found the culprit in `hackErrorStackToGetCallerFile`: when it tries to find the caller file by running `getFileName` in the stack trace entries, it is possible one of the entries is `undefined`, which results in the above error. One case this can happen is, for example, if there is a `require` inside an `eval()` statement (yeah, I know it is weird! In my case this happened because of a bluebird promisify call) Since `hackErrorStackToGetCallerFile` is called for any requires after using td.replace, this can happen anywhere, even outside the testdouble. 

My solution is to reject undefineds, since those do not help finding the caller file anyway.

If you are interested in reproducing this, the following code should do the trick:

**test.js**
```javascript
var td = require('testdouble');
td.replace('./a', () => {});
require('./b');
```

**b.js**
```javascript
eval('require("./c")');
```

(It doesn't matter what you have in a.js and c.js)