### PR TITLE
Node 8 compatibility

### DIFF
--- a/src/quibble.coffee
+++ b/src/quibble.coffee
@@ -77,7 +77,7 @@ requireWasCalledFromAFileThatHasQuibbledStuff = ->
 
 doWithoutCache = (request, parent, thingToDo) ->
   filename = Module._resolveFilename(request, parent)
-  if Module._cache.hasOwnProperty(filename)
+  if Object.prototype.hasOwnProperty.call(Module._cache, filename)
     doAndRestoreCache(filename, thingToDo)
   else
     doAndDeleteCache(filename, thingToDo)


### PR DESCRIPTION
`Module._cache` is a prototypeless object now, this changes the `hasOwnProperty` call to take that into account. @searls 