### PR TITLE
Add support for esm

### DIFF
--- a/esm-example/.gitignore
+++ b/esm-example/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/esm-example/lib/animals/bear.js
+++ b/esm-example/lib/animals/bear.js
@@ -1,0 +1,1 @@
+module.exports = function () { return 'a real bear' }

--- a/esm-example/lib/animals/lion.js
+++ b/esm-example/lib/animals/lion.js
@@ -1,0 +1,1 @@
+module.exports = function () { return 'a real lion' }

--- a/esm-example/lib/zoo.js
+++ b/esm-example/lib/zoo.js
@@ -1,0 +1,11 @@
+var lion = require('./animals/lion'),
+  bear = require('./animals/bear')
+
+module.exports = function () {
+  return {
+    animals: [
+      lion(),
+      bear()
+    ]
+  }
+}

--- a/esm-example/package.json
+++ b/esm-example/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "quibble-example",
+  "private": true,
+  "scripts": {
+    "test": "mocha -r esm -R spec --recursive test/helper.js test/lib/"
+  },
+  "devDependencies": {
+    "chai": "^3.3.0",
+    "esm": "^3.1.4",
+    "mocha": "^2.3.3",
+    "quibble": "file:.."
+  }
+}

--- a/esm-example/test/helper.js
+++ b/esm-example/test/helper.js
@@ -1,0 +1,16 @@
+global.expect = require('chai').expect
+global.context = describe
+quibble = require('quibble')
+
+beforeEach(function () {
+  // Config a default response for quibbles (usually in a spec helper)
+  quibble.config({
+    defaultFakeCreator: function (path) {
+      return function () { return 'a fake animal' }
+    }
+  })
+})
+
+afterEach(function () {
+  quibble.reset()
+})

--- a/esm-example/test/lib/zoo-spec.js
+++ b/esm-example/test/lib/zoo-spec.js
@@ -1,0 +1,22 @@
+quibble = require('quibble')
+
+require('../../lib/zoo') // drop the zoo in the cache
+
+describe('zoo', function () {
+  var subject
+
+  beforeEach(function () {
+    quibble('../../lib/animals/bear') // return ->'a fake animal'; see helper.js
+    quibble('../../lib/animals/lion', function () { return 'a fake lion' })
+
+    subject = require('../../lib/zoo')
+  })
+
+  it('contains a fake animal', function () {
+    expect(subject().animals).to.contain('a fake animal')
+  })
+
+  it('contains a fake lion', function () {
+    expect(subject().animals).to.contain('a fake lion')
+  })
+})

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -161,3 +161,12 @@ var hackErrorStackToGetCallerFile = function (includeGlobalIgnores) {
     Error.prepareStackTrace = originalFunc
   }
 }
+
+var esmPath
+try {
+  esmPath = resolve.sync('esm/esm', { paths: module.parent.paths })
+} catch (e) {}
+
+if (esmPath) {
+  quibble.ignoreCallsFromThisFile(esmPath)
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "test": "teenytest",
     "style": "standard --fix",
     "test:example": "cd example && npm it",
+    "test:esm-example": "cd esm-example && npm it",
     "test:smells": "./test/require-smell-test.sh",
-    "test:ci": "npm test && npm run style && npm run test:example && npm run test:smells",
+    "test:ci": "npm test && npm run style && npm run test:example && npm run test:esm-example && npm run test:smells",
     "preversion": "git pull --rebase && npm run test:ci",
     "postversion": "git push && git push --tags && npm publish"
   },
@@ -32,7 +33,8 @@
       "assert"
     ],
     "ignore": [
-      "example"
+      "example",
+      "esm-example"
     ]
   },
   "bugs": {


### PR DESCRIPTION
## What does this do?
Add support for libraries and apps using [esm](https://github.com/standard-things/esm), an ES6 module loader for node.

## Status
Works On My Machine™ when testing with `npm link` in this repo: https://github.com/pingortle/quibble-plus-esm

## To do
- [ ] Figure out how to test
  - First thought is to add a nested example project that depends on esm and `../index` with a simple test suite (similar to my repro repo above)
- [ ] Add tests

See https://github.com/testdouble/quibble/issues/13