### PR TITLE
support non-existing esm files

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -6,15 +6,15 @@ export const ignoreCallsFromThisFile = quibble.ignoreCallsFromThisFile
 export const config = quibble.config
 
 export async function resolve (specifier, context, defaultResolve) {
-  const resolveResult = await defaultResolve(
+  const resolve = () => defaultResolve(
     specifier.includes('__quibble')
       ? specifier.replace('?__quibbleresolvepath', '').replace('?__quibbleoriginal', '')
       : specifier,
-    context,
-    defaultResolve
+    context
   )
+
   if (specifier.includes('__quibbleresolvepath')) {
-    const resolvedPath = new URL(resolveResult.url).pathname
+    const resolvedPath = new URL(resolve().url).pathname
     const error = new Error()
     error.code = 'QUIBBLE_RESOLVED_PATH'
     error.resolvedPath = resolvedPath
@@ -22,33 +22,47 @@ export async function resolve (specifier, context, defaultResolve) {
   }
 
   if (!global.__quibble || !global.__quibble.quibbledModules) {
-    return resolveResult
+    return resolve()
   }
 
   const stubModuleGeneration = global.__quibble.stubModuleGeneration
 
   if (specifier.includes('__quibbleoriginal')) {
-    return resolveResult
+    return resolve()
   }
 
-  return { url: `${resolveResult.url}?__quibble=${stubModuleGeneration}` }
+  const { parentURL } = context
+
+  try {
+    const { url } = resolve()
+
+    return { url: `${url}?__quibble=${stubModuleGeneration}` }
+  } catch (error) {
+    if (error.code === 'ERR_MODULE_NOT_FOUND') {
+      return {
+        url: parentURL
+          ? `${new URL(specifier, parentURL).href}?__quibble=${stubModuleGeneration}`
+          : new URL(specifier).href
+      }
+    } else { throw error }
+  }
 }
 
-export async function transformSource (source, context, defaultTransformSource) {
-  const { url } = context
+export async function getSource (url, context, defaultGetSource) {
+  const source = () => defaultGetSource(url, context, defaultGetSource)
+
+  if (!global.__quibble || !global.__quibble.quibbledModules) {
+    return source()
+  }
   const urlUrl = new URL(url)
   const shouldBeQuibbled = urlUrl.searchParams.get('__quibble')
 
   if (!shouldBeQuibbled) {
-    return defaultTransformSource(source, context, defaultTransformSource)
+    return source()
   } else {
     const stubsInfo = getStubsInfo(urlUrl)
 
-    if (stubsInfo) {
-      return { source: transformModuleSource(stubsInfo) }
-    } else {
-      return defaultTransformSource(source, context, defaultTransformSource)
-    }
+    return stubsInfo ? { source: transformModuleSource(stubsInfo) } : source()
   }
 }
 

--- a/test/esm-lib/quibble-cjs.test.js
+++ b/test/esm-lib/quibble-cjs.test.js
@@ -43,6 +43,15 @@ module.exports = {
       life: 40
     })
   },
+  'works for modules that dont exist': async function () {
+    await quibble.esm('../esm-fixtures/this-module-does-not-exist.mjs', { named: 'named!' }, 'def-export')
+    const result = await import('../esm-fixtures/this-module-does-not-exist.mjs')
+
+    assert.deepEqual({ ...result }, {
+      default: 'def-export',
+      named: 'named!'
+    })
+  },
   'ignoreCallsFromThisFile works with ESM': async function () {
     const cjsImporingMjs = require('../esm-fixtures/a-module-ignored')
     const result1 = await cjsImporingMjs()

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -78,5 +78,11 @@ export default {
       namedExport: 'replacement 2',
       life: 40
     })
+  },
+  'mock a 3rd party lib': async function () {
+    await quibble.esm('is-promise', undefined, () => 42)
+
+    const { default: result } = await import('is-promise')
+    assert.equal(result(), 42)
   }
 }


### PR DESCRIPTION
@searls It seems that I missed a test: quibbling an esm module that does not exist. I found this out when working on testdouble. This PR adds a test and fixes the bug.

`testdouble.js` works with this fix (yay!), and is complete (except for documentation). Once this PR is merged and published, I will put the finishing touches on it, and PR it.