### PR TITLE
exception if using esm functionality but loader not loaded

### DIFF
--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -76,7 +76,7 @@ quibble.absolutify = function (relativePath, parentFileName) {
 }
 
 quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
-  if (!global.__quibble) { global.__quibble = { quibbledModules: new Map(), stubModuleGeneration: 1 } }
+  checkThatLoaderIsLoaded()
 
   if (!global.__quibble.quibbledModules) {
     global.__quibble.quibbledModules = new Map()
@@ -100,7 +100,13 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
   })
 }
 
+quibble.isLoaderLoaded = function () {
+  return !!global.__quibble
+}
+
 quibble.esmImportWithPath = async function esmImportWithPath (importPath) {
+  checkThatLoaderIsLoaded()
+
   const importPathIsBareSpecifier = isBareSpecifier(importPath)
   const isAbsolutePath = path.isAbsolute(importPath)
   const callerFile = isAbsolutePath || importPathIsBareSpecifier ? undefined : hackErrorStackToGetCallerFile()
@@ -220,6 +226,12 @@ var hackErrorStackToGetCallerFile = function (includeGlobalIgnores) {
   } finally {
     Error.prepareStackTrace = originalFunc
     Error.stackTraceLimit = originalStackTraceLimit
+  }
+}
+
+function checkThatLoaderIsLoaded () {
+  if (!global.__quibble) {
+    throw new Error('quibble loader not loaded. You cannot replace ES modules without a loader. Run node with `--loader=quibble`.')
   }
 }
 

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -4,6 +4,9 @@ export default quibble
 export const reset = quibble.reset
 export const ignoreCallsFromThisFile = quibble.ignoreCallsFromThisFile
 export const config = quibble.config
+export const isLoaderLoaded = quibble.isLoaderLoaded
+
+global.__quibble = { quibbledModules: new Map(), stubModuleGeneration: 1 }
 
 export async function resolve (specifier, context, defaultResolve) {
   const resolve = () => defaultResolve(
@@ -21,7 +24,7 @@ export async function resolve (specifier, context, defaultResolve) {
     throw error
   }
 
-  if (!global.__quibble || !global.__quibble.quibbledModules) {
+  if (!global.__quibble.quibbledModules) {
     return resolve()
   }
 
@@ -51,7 +54,7 @@ export async function resolve (specifier, context, defaultResolve) {
 export async function getSource (url, context, defaultGetSource) {
   const source = () => defaultGetSource(url, context, defaultGetSource)
 
-  if (!global.__quibble || !global.__quibble.quibbledModules) {
+  if (!global.__quibble.quibbledModules) {
     return source()
   }
   const urlUrl = new URL(url)
@@ -67,7 +70,7 @@ export async function getSource (url, context, defaultGetSource) {
 }
 
 function getStubsInfo (moduleUrl) {
-  if (!global.__quibble || !global.__quibble.quibbledModules) return undefined
+  if (!global.__quibble.quibbledModules) return undefined
 
   const moduleFilepath = moduleUrl.pathname
 

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "test": "teenytest",
     "style": "standard --fix",
     "test:esm": "if node test/supports-esm.js; then NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'; fi",
+    "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.{mjs,js}'; fi",
     "test:example": "cd example && npm it",
     "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example && npm it; fi",
     "test:smells": "./test/require-smell-test.sh",
-    "test:ci": "npm test && npm run test:esm && npm run style && npm run test:example && npm run test:example-esm && npm run test:smells",
+    "test:ci": "npm test && npm run test:esm && npm run test:no-loader-esm && npm run style && npm run test:example && npm run test:example-esm && npm run test:smells",
     "preversion": "git pull --rebase && npm run test:ci",
     "postversion": "git push && git push --tags && npm publish"
   },

--- a/test/esm-lib/quibble-cjs.test.js
+++ b/test/esm-lib/quibble-cjs.test.js
@@ -91,5 +91,8 @@ module.exports = {
       namedExport: 'named-export',
       life: 42
     })
+  },
+  'isLoaderLoader returns true if loader as loaded': async function () {
+    assert.equal(quibble.isLoaderLoaded(), true)
   }
 }

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -84,5 +84,8 @@ export default {
 
     const { default: result } = await import('is-promise')
     assert.equal(result(), 42)
+  },
+  'isLoaderLoader returns true if loader as loaded': async function () {
+    assert.equal(quibble.isLoaderLoaded(), true)
   }
 }

--- a/test/esm-lib/quibble.no-loader-test.js
+++ b/test/esm-lib/quibble.no-loader-test.js
@@ -1,0 +1,24 @@
+const quibble = require('quibble')
+
+module.exports = {
+  'throw exception on quibble.esm with no loader': async function () {
+    await assertThrows(() => quibble.esm('../esm-fixtures/a-module.mjs'),
+      'quibble loader not loaded')
+  },
+  'throw exception on quibble.esmImportWithPath with no loader': async function () {
+    await assertThrows(() => quibble.esmImportWithPath('../esm-fixtures/a-module.mjs'),
+      'quibble loader not loaded')
+  },
+  'isLoaderLoader returns false if no loader': async function () {
+    assert.equal(quibble.isLoaderLoaded(), false)
+  }
+}
+
+async function assertThrows (asyncFunc, messageContained) {
+  try {
+    asyncFunc()
+    assert.fail(`function did not throw exception with ${messageContained}`)
+  } catch (err) {
+    assert.equal(err.message.includes(messageContained), true)
+  }
+}


### PR DESCRIPTION
Currently, if you use quibble.esm (and other ESM methods), and yet did not use `node --loader=...`,
the results are unpredictable. It would be better to throw an exception and notify the user.

This is what this PR does. It also adds a function `isLoaderLoaded` that enables other, higher-level
libraries like testdouble.js to implement this themselves.﻿
