### PR TITLE
fix bug in handling internal modules

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -6,7 +6,7 @@ export const ignoreCallsFromThisFile = quibble.ignoreCallsFromThisFile
 export const config = quibble.config
 export const isLoaderLoaded = quibble.isLoaderLoaded
 
-global.__quibble = { quibbledModules: new Map(), stubModuleGeneration: 1 }
+global.__quibble = { stubModuleGeneration: 1 }
 
 export async function resolve (specifier, context, defaultResolve) {
   const resolve = () => defaultResolve(
@@ -39,7 +39,7 @@ export async function resolve (specifier, context, defaultResolve) {
   try {
     const { url } = resolve()
 
-    return { url: `${url}?__quibble=${stubModuleGeneration}` }
+    return { url: url.startsWith('nodejs:') ? url : `${url}?__quibble=${stubModuleGeneration}` }
   } catch (error) {
     if (error.code === 'ERR_MODULE_NOT_FOUND') {
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2153,9 +2153,9 @@
       }
     },
     "teenytest": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teenytest/-/teenytest-6.0.1.tgz",
-      "integrity": "sha512-gupsqwZbcfHzCVlaXSt4ZqXKWhXRsBhOQT5FbcD7fTr8NpQQM2Rn5OUQrrSHzyycVs66hy+X8lGPAo244axrwA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/teenytest/-/teenytest-6.0.2.tgz",
+      "integrity": "sha512-54ATJlqxe3uZt+MABHLI9oouwNQT+/vauiWaoIFpvYq3lVS70e5/EOqnqt0qc92XyawdQTUe3BA7DW5nwQ4oUQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "is-number": "^7.0.0",
     "is-promise": "^4.0.0",
     "standard": "^14.3.3",
-    "teenytest": "^6.0.1",
+    "teenytest": "^6.0.2",
     "teenytest-promise": "^1.0.0"
   },
   "standard": {

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -1,3 +1,6 @@
+// This import is important and part of the test,
+// as it checks how quibble interacts with internal modules
+import 'fs'
 import quibble from 'quibble'
 
 export default {
@@ -8,6 +11,9 @@ export default {
       life: 41,
       namedFunctionExport: () => 'export replacement'
     }, 'default-export-replacement')
+
+    // This import is important, as it checks how quibble interacts with internal modules
+    await import('util')
 
     const result = await import('../esm-fixtures/a-module-with-function.mjs')
     assert.equal(result.default, 'default-export-replacement')


### PR DESCRIPTION
Working on testdouble exposed a dormant bug: the quibble ESM loader handles internal node.js module﻿ (e.g. 'fs') poorly, as in not at all. Amazing that I just found that out now!

Anyway, fixed, and as usual, to continue with testdouble.js (all tests pass when I copy over the fix!), I need a new version.

(Sorry about the constant to and fro. 
I would have npm-linked testdouble to quibble until everything worked, but the TS support
kept changing the quibble's `import`-s into `require`-s, so I can't npm-link the module to check it. Hopefully, this is the last one... :->)
