### PR TITLE
ESM: support new "node:" scheme that replaces "nodejs:"

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -41,7 +41,8 @@ export async function resolve (specifier, context, defaultResolve) {
 
     const quibbledUrl = `${url}?__quibble=${stubModuleGeneration}`
 
-    if (url.startsWith('nodejs:') && !getStubsInfo(new URL(quibbledUrl))) return { url }
+    // 'node:' is the prefix for Node >=14.13. 'nodejs:' is for earlier versions
+    if (/^node(js){0,1}:/.test(url) && !getStubsInfo(new URL(quibbledUrl))) return { url }
 
     return { url: quibbledUrl }
   } catch (error) {


### PR DESCRIPTION
Fixes https://github.com/testdouble/testdouble.js/issues/457

Node v14.13 changed the scheme for builtin modules from `nodejs:` to `node:`. This PR supports both.