### PR TITLE
fixes #468: td.replaceEsm() multiple replaces not working

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,7 +12,7 @@
       }
     },
     "..": {
-      "version": "0.6.5",
+      "version": "0.6.6",
       "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
       "dev": true,
       "license": "MIT",

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -80,8 +80,8 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
 
   if (!global.__quibble.quibbledModules) {
     global.__quibble.quibbledModules = new Map()
-    ++global.__quibble.stubModuleGeneration
   }
+  ++global.__quibble.stubModuleGeneration
   importFunctionsModule = importFunctionsModule || require('./esm-import-functions')
 
   const importPathIsBareSpecifier = isBareSpecifier(importPath)

--- a/test/esm-fixtures/b-module.mjs
+++ b/test/esm-fixtures/b-module.mjs
@@ -1,0 +1,4 @@
+export const life = 43
+export const namedExport = 'named-export-b'
+
+export default 'default-export-b'

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -85,6 +85,16 @@ export default {
       life: 40
     })
   },
+  'mock two modules': async function () {
+    await quibble.esm('../esm-fixtures/a-module.mjs', { a: 4 }, 'a-mock')
+
+    await import('../esm-fixtures/b-module.mjs')
+
+    await quibble.esm('../esm-fixtures/b-module.mjs', { a: 4 }, 'b-mock')
+
+    assert.deepEqual((await import('../esm-fixtures/a-module.mjs')).default, 'a-mock')
+    assert.deepEqual((await import('../esm-fixtures/b-module.mjs')).default, 'b-mock')
+  },
   'mock a 3rd party lib': async function () {
     await quibble.esm('is-promise', undefined, () => 42)
 


### PR DESCRIPTION
The bug was a stupid one, and am actually not sure how it worked before!
Any `quibble.esm` should have updated the generation to ensure that fresh non-cache copies are loaded
once there is a change in mocking. But the generation was only incremented once, in the first `quibble.esm`.
This was fixed by moving the increment operation out of the `if`.