### PR TITLE
Fail if file doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log*
 
 #ignore node_modules, as the node project is not "deployed" per se: http://www.mikealrogers.com/posts/nodemodules-in-git.html
 /node_modules
+.DS_Store

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -2,6 +2,7 @@ var Module = require('module')
 var path = require('path')
 var { URL } = require('url')
 var resolve = require('resolve')
+var { accessSync, constants } = require('fs')
 var _ = {
   compact: require('lodash/fp/compact'),
   extendAll: require('lodash/fp/extendAll'),
@@ -93,6 +94,7 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
     : isAbsolutePath
       ? importPath
       : path.resolve(path.dirname(callerFile), importPath)
+  accessSync(fullModulePath, constants.R_OK)
 
   global.__quibble.quibbledModules.set(fullModulePath, {
     defaultExportStub,


### PR DESCRIPTION
- Fixes #64

To authors:

- when I now run `npm run test:esm` I find a lot of errors saying that modules were not found. I'm confused whether these errors appear as checking for a file's existence has been neglected or because I'm breaking fundamental assumptions.
- Please help me towards merging this PR, thanks.