### PR TITLE
handle multiple versions within node_modules

### DIFF
--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -71,7 +71,7 @@ quibble.absolutify = function (relativePath, parentFileName) {
     parentFileName = hackErrorStackToGetCallerFile()
   }
   var absolutePath = absolutePathFor(relativePath, parentFileName)
-  var resolvedPath = nodeResolve(absolutePath)
+  var resolvedPath = nodeResolve(absolutePath, { basedir: path.dirname(parentFileName) })
   return resolvedPath || absolutePath
 }
 
@@ -192,9 +192,9 @@ var doAndDeleteCache = function (filename, thingToDo) {
   })
 }
 
-var nodeResolve = function (request) {
+var nodeResolve = function (request, options) {
   try {
-    return resolve.sync(request)
+    return resolve.sync(request, options)
   } catch (e) {}
 }
 

--- a/test/fixtures/node_modules/is-number/index.js
+++ b/test/fixtures/node_modules/is-number/index.js
@@ -1,0 +1,4 @@
+// Fake dependency to test importing node_modules
+module.exports = function() {
+  return false;
+};

--- a/test/fixtures/node_modules/is-number/package.json
+++ b/test/fixtures/node_modules/is-number/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "is-number",
+  "description": "Fake dependency to test importing node_modules",
+  "version": "100.0.0",
+  "files": [
+    "index.js"
+  ],
+  "main": "index.js"
+}

--- a/test/fixtures/requires-a-node-module.js
+++ b/test/fixtures/requires-a-node-module.js
@@ -1,0 +1,7 @@
+// This should import the fake dependency in './node_modules/is-number'
+// not the real dependency in '../../node_modules/is-number'
+var isNumber = require("is-number");
+
+module.exports = function () {
+  return isNumber(1);
+};

--- a/test/lib/quibble.test.js
+++ b/test/lib/quibble.test.js
@@ -121,6 +121,12 @@ module.exports = {
       assert.equal(result, 'loaded a fake function')
     }
   },
+  'requiring-a-node-module': function () {
+    quibble('./some-other-thing')
+    const quibbledRequiresANodeModule = require('../fixtures/requires-a-node-module')
+
+    assert.equal(quibbledRequiresANodeModule(), false);
+  },
   afterEach: function () {
     quibble.reset()
   },


### PR DESCRIPTION
Hey there! I noticed a situation where I had 

```
| ./node_modules
     | - dependency@1.0.0
| - ./packages 
     | - ./some-package
          | - ./node_modules
               | - dependency@2.0.0
```

And quibble would always resolve to the `1.0.0` version, even from within `some-package` . This PR has a fix, but I'm not sure how you'd like to test it - the fixture would be quite complex. Let me know!