### PR TITLE
fix esm mocks on windows

### DIFF
--- a/lib/esm-import-functions.js
+++ b/lib/esm-import-functions.js
@@ -3,7 +3,14 @@
 // The way it is dealt with is that we require this module only in code paths in `quibble.js`
 // that are ESM related.
 
+// TODO: use import.meta.resolve when that is standardized.
+// https://nodejs.org/api/esm.html#importmetaresolvespecifier-parent
 exports.dummyImportModuleToGetAtPath = async function dummyImportModuleToGetAtPath (modulePath) {
+  // Cannot intercept import with loader API for things like `fs?__quibbleresolvepath`.
+  if (process.binding('natives')[modulePath]) {
+    return null;
+  }
+
   try {
     await import(modulePath + (modulePath.includes('?') ? '&' : '?') + '__quibbleresolvepath')
   } catch (error) {

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -1,6 +1,6 @@
 var Module = require('module')
 var path = require('path')
-var { URL } = require('url')
+var { URL, pathToFileURL, fileURLToPath } = require('url')
 var resolve = require('resolve')
 var _ = {
   compact: require('lodash/fp/compact'),
@@ -94,7 +94,10 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
       ? importPath
       : path.resolve(path.dirname(callerFile), importPath)
 
-  global.__quibble.quibbledModules.set(fullModulePath, {
+  const moduleKey = importPathIsBareSpecifier && fullModulePath === null
+    ? importPath
+    : pathToFileURL(fullModulePath).pathname
+  global.__quibble.quibbledModules.set(moduleKey, {
     defaultExportStub,
     namedExportStubs
   })
@@ -119,9 +122,7 @@ quibble.esmImportWithPath = async function esmImportWithPath (importPath) {
       ? importPath
       : path.resolve(path.dirname(callerFile), importPath)
 
-  const fullImportPath = importPathIsBareSpecifier
-    ? importPath
-    : modulePath
+  const fullImportPath = pathToFileURL(modulePath).href
 
   return {
     modulePath,
@@ -236,8 +237,10 @@ function checkThatLoaderIsLoaded () {
 }
 
 function convertUrlToPath (fileUrl) {
+  if (!fileUrl.startsWith('file://')) return fileUrl
+
   try {
-    const p = new URL(fileUrl).pathname
+    const p = fileURLToPath(fileUrl)
     return p
   } catch (error) {
     if (error.code === 'ERR_INVALID_URL') {

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -1,3 +1,4 @@
+import url from 'url'
 import quibble from './quibble.js'
 
 export default quibble
@@ -17,7 +18,7 @@ export async function resolve (specifier, context, defaultResolve) {
   )
 
   if (specifier.includes('__quibbleresolvepath')) {
-    const resolvedPath = new URL((await resolve()).url).pathname
+    const resolvedPath = url.fileURLToPath((await resolve()).url)
     const error = new Error()
     error.code = 'QUIBBLE_RESOLVED_PATH'
     error.resolvedPath = resolvedPath

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "test": "teenytest",
     "style": "standard --fix",
-    "test:esm": "if node test/supports-esm.js; then NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'; fi",
+    "test:esm": "NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'",
+    "win:test:esm": "cp node_modules/teenytest/bin/teenytest node_modules/teenytest/bin/teenytest.js && node --loader=quibble node_modules/teenytest/bin/teenytest.js ./test/esm-lib/*.test.{mjs,js}",
     "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.{mjs,js}'; fi",
     "test:example": "cd example && npm it",
     "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example && npm it; fi",

--- a/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
+++ b/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const url = require('url')
 const quibble = require('quibble')
 
 module.exports = {


### PR DESCRIPTION
ref https://github.com/testdouble/testdouble.js/issues/491

Note: I am away from my windows machine so this is not yet verified. How can I configure the travis yml to run the tests on windows?

