### PR TITLE
fix module cache breaking for modules not being mocked

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -1,3 +1,4 @@
+import url from 'url'
 import quibble from './quibble.js'
 
 export default quibble
@@ -26,6 +27,24 @@ export async function resolve (specifier, context, defaultResolve) {
 
   if (!global.__quibble.quibbledModules) {
     return resolve()
+  }
+
+  try {
+    // If this module is not being mocked by quibble, return the default resolved module url.
+    // Otherwise, a slightly different url with `stubModuleGeneration` appended will result in
+    // Node re-evaluating the module and breaking expectations around the module cache (ex: a
+    // class from a module not being mocked should always be equal throughout the lifetime of
+    // the program).
+    const resolvedUrl = await resolve()
+    if (!resolvedUrl.url.startsWith('node:')) {
+      const resolvedPath = url.fileURLToPath(resolvedUrl.url)
+      if (!global.__quibble.quibbledModules.has(resolvedPath)) {
+        return resolvedUrl
+      }
+    }
+  } catch (err) {
+    // Without this, the test `works for modules that dont exist` fails.
+    if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err
   }
 
   const stubModuleGeneration = global.__quibble.stubModuleGeneration
@@ -80,8 +99,8 @@ function getStubsInfo (moduleUrl) {
   if (!moduleUrl.searchParams.get('__quibble')) return undefined
 
   const moduleFilepath = moduleUrl.pathname
-
-  return [...global.__quibble.quibbledModules.entries()].find(([m]) => m === moduleFilepath)
+  const stub = global.__quibble.quibbledModules.get(moduleFilepath)
+  return stub ? [moduleFilepath, stub] : undefined
 }
 
 function transformModuleSource ([moduleKey, stubs]) {

--- a/test/esm-fixtures/a-module-never-mocked.mjs
+++ b/test/esm-fixtures/a-module-never-mocked.mjs
@@ -1,0 +1,1 @@
+export class NeverMockMeUnderPenaltyOfDeath {}

--- a/test/esm-fixtures/a-module-with-a-dependency.mjs
+++ b/test/esm-fixtures/a-module-with-a-dependency.mjs
@@ -1,0 +1,5 @@
+import { NeverMockMeUnderPenaltyOfDeath } from "./a-module-never-mocked.mjs"
+
+export function getString() {
+  return 'original'
+}

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -114,5 +114,21 @@ export default {
     const fs = await import('fs')
 
     assert.equal(await fs.readFileSync(), 42)
-  }
+  },
+  'mocking a module does not break module cache for dependency modules': async function () {
+    const {NeverMockMeUnderPenaltyOfDeath} = await import('../esm-fixtures/a-module-never-mocked.mjs')
+
+    await quibble.esm('../esm-fixtures/a-module-with-a-dependency.mjs', {
+      getString: () => 'replaced'
+    })
+    
+    const result = await import('../esm-fixtures/a-module-with-a-dependency.mjs')
+    assert.equal(result.getString(), 'replaced')
+
+    await import('../esm-fixtures/a-module-never-mocked.mjs')
+    assert.equal(
+      (await import('../esm-fixtures/a-module-never-mocked.mjs')).NeverMockMeUnderPenaltyOfDeath,
+      NeverMockMeUnderPenaltyOfDeath
+    )
+  },
 }


### PR DESCRIPTION
This resolves https://github.com/testdouble/testdouble.js/issues/492 without breaking any existing tests.

Confirmed this work great in our usage of testdouble in Lighthouse tests
