### PR TITLE
fix node 18.6 incompatibility with new loader interface

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -128,13 +128,13 @@ ${
  * @param {{
  *   format: string,
  * }} context
- * @param {Function} defaultLoad
+ * @param {Function} nextLoad
  * @returns {Promise<{ source: !(string | SharedArrayBuffer | Uint8Array), format: string}>}
  */
-export async function load (url, context, defaultLoad) {
+export async function load (url, context, nextLoad) {
   const stubsInfo = getStubsInfo(new URL(url))
 
   return stubsInfo
-    ? { source: transformModuleSource(stubsInfo), format: 'module' }
-    : defaultLoad(url, context, defaultLoad)
+    ? { source: transformModuleSource(stubsInfo), format: 'module', shortCircuit: true }
+    : nextLoad(url, context, nextLoad)
 }


### PR DESCRIPTION
Quibble breaks in Node.js v18.6.0 and higher due to a change done in the ESM loader interface (related to multiple loaders).