### PR TITLE
never mock quibble

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -28,6 +28,10 @@ export async function resolve (specifier, context, defaultResolve) {
     return resolve()
   }
 
+  if (specifier === 'quibble') {
+    return resolve()
+  }
+
   const stubModuleGeneration = global.__quibble.stubModuleGeneration
 
   if (specifier.includes('__quibbleoriginal')) {

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -114,5 +114,18 @@ export default {
     const fs = await import('fs')
 
     assert.equal(await fs.readFileSync(), 42)
+  },
+  'quibble is never mocked': async function () {
+    await quibble.esm('fs', {
+      async readFileSync () {
+        return 42
+      }
+    })
+
+    await import('quibble')
+
+    const fs = await import('fs')
+
+    assert.equal(await fs.readFileSync(), 42)
   }
 }


### PR DESCRIPTION
If `quibble` happens to be imported after initial use, it essentially resets the `global.__quibble` state resulting in either total failure (cannot access 'get' of undefined) or a module not being mocked (such as for builtins like fs)

To prevent this, simply return early in `resolve` if the specifier is `quibble`.