### PR TITLE
fix(loader): make sure loaded status is only set on loader hook

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -6,7 +6,17 @@ export const ignoreCallsFromThisFile = quibble.ignoreCallsFromThisFile
 export const config = quibble.config
 export const isLoaderLoaded = quibble.isLoaderLoaded
 
-global.__quibble = { stubModuleGeneration: 1 }
+function loadQuibble () {
+  global.__quibble = { stubModuleGeneration: 1 }
+}
+
+export function globalPreload () {
+  return `(${loadQuibble.toString()})()`
+}
+
+export function getGlobalPreloadCode () {
+  return `(${loadQuibble.toString()})()`
+}
 
 export async function resolve (specifier, context, nextResolve) {
   const resolve = () => nextResolve(

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "teenytest",
     "style": "standard --fix",
     "test:esm": "if node test/supports-esm.js; then NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'; fi",
-    "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.{mjs,js}'; fi",
+    "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.js' && teenytest './test/esm-lib/*.no-loader-test.mjs'; fi",
     "test:example": "cd example && npm it",
     "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example && npm it; fi",
     "test:smells": "./test/require-smell-test.sh",

--- a/test/esm-lib/quibble.no-loader-test.mjs
+++ b/test/esm-lib/quibble.no-loader-test.mjs
@@ -1,0 +1,7 @@
+import quibble from 'quibble'
+
+export default {
+  'isLoaderLoader returns false if no loader': async function () {
+    assert.equal(quibble.isLoaderLoaded(), false)
+  }
+}


### PR DESCRIPTION
Make sure the `isLoaded` state is explicitly set through the NodeJS loader life-cycle, instead of through global/implicit imports of the file. This makes sure the state is _only_ set when the file is loaded through a NodeJS loader.

To not worry about unloaded/loading states, I simply separated the loader tests (MJS and JS) through two different `teenytest` processes.

fixes #77 