### PR TITLE
fix: enable running on Windows

### DIFF
--- a/lib/esm-import-functions.js
+++ b/lib/esm-import-functions.js
@@ -1,3 +1,4 @@
+var path = require('path')
 // These functions are in a separate file due to the fact that we need to support Node.js v8, which
 // cannot parse the `import` syntax.
 // The way it is dealt with is that we require this module only in code paths in `quibble.js`
@@ -5,6 +6,9 @@
 
 exports.dummyImportModuleToGetAtPath = async function dummyImportModuleToGetAtPath (modulePath) {
   try {
+    if (path.isAbsolute(modulePath)) {
+      modulePath = 'file://' + modulePath
+    }
     await import(modulePath + (modulePath.includes('?') ? '&' : '?') + '__quibbleresolvepath')
   } catch (error) {
     if (error.code === 'QUIBBLE_RESOLVED_PATH') {
@@ -19,4 +23,9 @@ exports.dummyImportModuleToGetAtPath = async function dummyImportModuleToGetAtPa
   )
 }
 
-exports.importOriginalModule = (fullImportPath) => import(fullImportPath + '?__quibbleoriginal')
+exports.importOriginalModule = async (fullImportPath) => {
+  if (path.isAbsolute(fullImportPath)) {
+    fullImportPath = 'file://' + fullImportPath
+  }
+  return import(fullImportPath + '?__quibbleoriginal')
+}

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -11,7 +11,6 @@ var _ = {
   ooFind: require('lodash/find'),
   flow: require('lodash/fp/flow'),
   invokeMap: require('lodash/fp/invokeMap'),
-  isPlainObject: require('lodash/fp/isPlainObject'),
   map: require('lodash/fp/map'),
   includes: require('lodash/fp/includes'),
   reject: require('lodash/fp/reject'),
@@ -103,13 +102,21 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
 
   const importPathIsBareSpecifier = isBareSpecifier(importPath)
   const isAbsolutePath = path.isAbsolute(importPath)
-  const callerFile = isAbsolutePath || importPathIsBareSpecifier ? undefined : hackErrorStackToGetCallerFile()
 
-  const fullModulePath = importPathIsBareSpecifier
+  let callerFile
+  if (!isAbsolutePath && !importPathIsBareSpecifier) {
+    callerFile = hackErrorStackToGetCallerFile()
+    if (process.platform === 'win32' && callerFile[0] === '/') {
+      callerFile = callerFile.substring(1)
+    }
+  }
+
+  const modulePath = importPathIsBareSpecifier
     ? await importFunctionsModule.dummyImportModuleToGetAtPath(importPath)
     : isAbsolutePath
       ? importPath
-      : path.resolve(path.dirname(callerFile), importPath)
+      : (path.resolve(path.dirname(callerFile), importPath))
+  const fullModulePath = process.platform !== 'win32' ? modulePath : (modulePath.match(/^[a-zA-Z]:/) ? '/' : '') + modulePath.split(path.sep).join('/')
 
   global.__quibble.quibbledModules.set(fullModulePath, {
     defaultExportStub,
@@ -124,21 +131,26 @@ quibble.isLoaderLoaded = function () {
 quibble.esmImportWithPath = async function esmImportWithPath (importPath) {
   checkThatLoaderIsLoaded()
 
+  importFunctionsModule = importFunctionsModule || require('./esm-import-functions')
+
   const importPathIsBareSpecifier = isBareSpecifier(importPath)
   const isAbsolutePath = path.isAbsolute(importPath)
-  const callerFile = isAbsolutePath || importPathIsBareSpecifier ? undefined : hackErrorStackToGetCallerFile()
-
-  importFunctionsModule = importFunctionsModule || require('./esm-import-functions')
+  let callerFile
+  if (!isAbsolutePath && !importPathIsBareSpecifier) {
+    callerFile = hackErrorStackToGetCallerFile()
+    if (process.platform === 'win32' && callerFile[0] === '/') {
+      callerFile = callerFile.substring(1)
+    }
+  }
 
   const modulePath = importPathIsBareSpecifier
     ? await importFunctionsModule.dummyImportModuleToGetAtPath(importPath)
     : isAbsolutePath
       ? importPath
-      : path.resolve(path.dirname(callerFile), importPath)
-
+      : (path.resolve(path.dirname(callerFile), importPath))
   const fullImportPath = importPathIsBareSpecifier
     ? importPath
-    : modulePath
+    : (process.platform !== 'win32' ? modulePath : (modulePath.match(/^[a-zA-Z]:/) ? '/' : '') + modulePath.split(path.sep).join('/'))
 
   return {
     modulePath,
@@ -254,7 +266,7 @@ function checkThatLoaderIsLoaded () {
 
 function convertUrlToPath (fileUrl) {
   try {
-    const p = new URL(fileUrl).pathname
+    const p = fileUrl.match(/^[a-zA-Z]:/) ? fileUrl : new URL(fileUrl).pathname
     return p
   } catch (error) {
     if (error.code === 'ERR_INVALID_URL') {

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -22,7 +22,7 @@ export async function resolve (specifier, context, nextResolve) {
   const resolve = () => nextResolve(
     specifier.includes('__quibble')
       ? specifier.replace('?__quibbleresolvepath', '').replace('?__quibbleoriginal', '')
-      : specifier,
+      : (specifier.match(/^[a-zA-Z]:/) ? `file://${specifier}` : specifier),
     context
   )
 

--- a/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
+++ b/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
@@ -15,11 +15,11 @@ module.exports = {
   },
   'support importing esm and returning the path for a bare specifier': async function () {
     // This test that `is-promise` is a dual-mode module where
-    // the entry points are index.js and index.mjs. If thie changes in the future, you
+    // the entry points are index.js and index.mjs. If this changes in the future, you
     // can always create a module of your own and put it in node_modules.
     const { modulePath, module } = await quibble.esmImportWithPath('is-promise')
 
-    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs'))
+    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs').replace(/\\/g, '/').replace(/^([a-zA-Z]:)/, '/$1'))
     const { default: isPromise, ...rest } = module
     assert.deepEqual(rest, {})
     assert.deepEqual(isPromise(Promise.resolve()), true)
@@ -47,7 +47,7 @@ module.exports = {
     await quibble.esm('is-promise', undefined, 42)
     const { modulePath, module } = await quibble.esmImportWithPath('is-promise')
 
-    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs'))
+    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs').replace(/\\/g, '/').replace(/^([a-zA-Z]:)/, '/$1'))
     const { default: isPromise, ...rest } = module
     assert.deepEqual(rest, {})
     assert.deepEqual(isPromise(Promise.resolve()), true)


### PR DESCRIPTION
`import` on Windows requires using the `file://` url.  This can be used on all platforms for absolute paths.

`hackErrorStackToGetCallerFile()` returns a pathname which includes a leading '/'.  This must be removed on Windows for `path.resolve` but added back along with converting '\\' to '/' for the import path.

This is to support the CI run of [semantic-release v20](https://github.com/semantic-release/semantic-release/) which uses `testdouble`.  There are a couple of PRs for that project for Windows support as well.  The CI runs under Windows with these changes and the other changes.

The tests have been run under Windows wsl.  The `esm` and `no-loader-esm` tests fail on native Windows due to `teenytest` issues with Windows.  The remaining tests run on Windows.