### PR TITLE
Fix esm api documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,19 @@ console.log(life, universe);
 })();
 ```
 
-The parameters to `quibble` for ESM modules are:
+The parameters to be given to `quibble.esm` for ESM modules are:
 
 1. the module path: similar to CommonJS, the path is relative to the directory you are in. It is
    resolved the ESM way, so if you're using a relative path, you must specify the filename,
    including the extension.
+2. the named export stubs: either null/undefied or an object with each property
+   having key corresponding to export names and value being the implementation
+   to use. To define the `default` export you can either define a `default`
+   property here or use the third argument, but not both at same time.
+3. the default export stub: if named export stubs does not contain a `default`
+   key, you can define the default stub with this argument.
 
-* `quibble.reset` works the same as for CommonJS modules
+Note that `quibble.reset` works the same as for CommonJS modules
 
 ESM support also exposes the function `quibble.esmImportWithPath` which both imports a module and
 resolves the path to the module that is the package's entry point:

--- a/example-esm/test/helper.js
+++ b/example-esm/test/helper.js
@@ -1,9 +1,9 @@
 const { beforeEach, afterEach } = require('mocha')
 const quibble = require('quibble')
 
-beforeEach(function () {
-  quibble('../lib/animals/bear.mjs', undefined, function () { return 'a fake bear' })
-  quibble('../lib/animals/lion.mjs', undefined, function () { return 'a fake lion' })
+beforeEach(async function () {
+  await quibble.esm('../lib/animals/bear.mjs', undefined, function () { return 'a fake bear' })
+  await quibble.esm('../lib/animals/lion.mjs', { default: function () { return 'a fake lion' }})
 })
 
 afterEach(function () {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:esm": "if node test/supports-esm.js; then NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'; fi",
     "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.js' && teenytest './test/esm-lib/*.no-loader-test.mjs'; fi",
     "test:example": "cd example && npm it",
-    "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example && npm it; fi",
+    "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example-esm && npm it; fi",
     "test:smells": "./test/require-smell-test.sh",
     "test:ci": "npm test && npm run test:esm && npm run test:no-loader-esm && npm run style && npm run test:example && npm run test:example-esm && npm run test:smells",
     "preversion": "git pull --rebase && npm run test:ci",


### PR DESCRIPTION
The npm script `test:example-esm` was running the `example` tests instead of `example-esm`.

I've fixed the script command and I had to fix the `example-esm` itself too to use the `quibble.esm` API instead of `quibble`.

I've also updated the `example-esm` to illustrate both way to define the `default` export.

Finally, I added a second commit to list all arguments the `quibble.esm` method can receive and how to use it.