### PR TITLE
ci: migrate to node v14 and expand Windows support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "teenytest-promise": "^1.0.0"
       },
       "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
+        "node": ">= 0.14.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "scripts": {
     "test": "teenytest",
     "style": "standard --fix",
-    "test:esm": "if node test/supports-esm.js; then NODE_OPTIONS=--loader=quibble ./test/esm-lib/teenytest-proxy.js './test/esm-lib/*.test.{mjs,js}'; fi",
-    "test:no-loader-esm": "if node test/supports-esm.js; then teenytest './test/esm-lib/*.no-loader-test.js' && teenytest './test/esm-lib/*.no-loader-test.mjs'; fi",
+    "test:esm": "node --loader=quibble ./test/esm-lib/teenytest-proxy.js ./test/esm-lib/*.test.{mjs,js}",
+    "test:no-loader-esm": "teenytest ./test/esm-lib/*.no-loader-test.js && teenytest ./test/esm-lib/*.no-loader-test.mjs",
     "test:example": "cd example && npm it",
-    "test:example-esm": "if node test/supports-esm.js; then node test/supports-esm.js && cd example && npm it; fi",
-    "test:smells": "./test/require-smell-test.sh",
+    "test:example-esm": "cd example && npm it",
+    "test:smells": "bash ./test/require-smell-test.sh",
     "test:ci": "npm test && npm run test:esm && npm run test:no-loader-esm && npm run style && npm run test:example && npm run test:example-esm && npm run test:smells",
     "preversion": "git pull --rebase && npm run test:ci",
     "postversion": "git push && git push --tags && npm publish"
@@ -62,8 +62,7 @@
     "url": "https://github.com/testdouble/quibble.git"
   },
   "engines": {
-    "node": ">= 0.12.0",
-    "iojs": ">= 1.0.0"
+    "node": ">= 0.14.0"
   },
   "license": "MIT"
 }

--- a/test/esm-lib/teenytest-proxy.js
+++ b/test/esm-lib/teenytest-proxy.js
@@ -6,4 +6,4 @@
 //
 // Once these bugs are solved, we can go back to running teenytest regularly for ESM tests
 
-require('../../node_modules/.bin/teenytest')
+require('../../node_modules/teenytest/bin/teenytest')


### PR DESCRIPTION
1. ci - teenytest-proxy Windows support
    npm installs packages differently based on the platform.  The `.bin` entry the proxy was using is a symlink on UNIX type platforms but may have three different forms on WIndows.  The actual installed package will now  be required directly.  This is still a temporary patch pending fixes for the issues identified in the proxy file.
1. ci - make node v14 min level for Windows support
    Remove use of test/supports-esm.js.  Some quoting is removed since the command is not in a shell.

Tested running under Windows wsl, direct bash shell on Windows and cmd prompt.