### PR TITLE
allow proxy as default export

### DIFF
--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -1,5 +1,6 @@
 const Module = require('module')
 const path = require('path')
+const util = require('util')
 const { URL } = require('url')
 const resolve = require('resolve')
 const isPlainObject = require('lodash/isPlainObject.js')
@@ -79,7 +80,7 @@ quibble.absolutify = function (relativePath, parentFileName) {
 quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
   checkThatLoaderIsLoaded()
 
-  if (namedExportStubs != null && !isPlainObject(namedExportStubs)) {
+  if (namedExportStubs != null && !util.types.isProxy(namedExportStubs) && !isPlainObject(namedExportStubs)) {
     throw new Error('namedExportsStub argument must be either a plain object or null/undefined')
   }
 

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -167,6 +167,9 @@ export default {
     await assertThrows(() => quibble.esm('../esm-fixtures/a-module.mjs',
       function () { 'this should be an object' })
     , 'namedExportsStub argument must be either a plain object')
+
+    // Should still allow Proxy.
+    await quibble.esm('../esm-fixtures/a-module.mjs', new Proxy({}, {}))
   }
 }
 


### PR DESCRIPTION
Currently, setting a Proxy object as the default export will error within lodash's `isPlainObject`:

```
TypeError: Cannot convert a Symbol value to a string
    at Object.get (file:///Users/cjamcl/src/lighthouse/core/test/gather/mock-driver.js:288:74)
    at Proxy.toString (<anonymous>)
    at objectToString (/Users/cjamcl/src/lighthouse/node_modules/lodash/_objectToString.js:19:31)
    at baseGetTag (/Users/cjamcl/src/lighthouse/node_modules/lodash/_baseGetTag.js:25:7)
    at isPlainObject (/Users/cjamcl/src/lighthouse/node_modules/lodash/isPlainObject.js:50:31)
    at Function.quibble.esm (/Users/cjamcl/src/lighthouse/node_modules/quibble/lib/quibble.js:83:36)
    at replaceEsModule (/Users/cjamcl/src/lighthouse/node_modules/testdouble/lib/replace/module/index.js:38:24)
    at Module.replaceEsm (/Users/cjamcl/src/lighthouse/node_modules/testdouble/lib/replace/index.js:24:41)
--------
    at mockDriverSubmodules (file:///Users/cjamcl/src/lighthouse/core/test/gather/mock-driver.js:292:12)
    at file:///Users/cjamcl/src/lighthouse/core/test/gather/gatherers/dobetterweb/response-compression-test.js:9:21
```

This patch allow a Proxy object to pass this object check.