### PR TITLE
ci: suppress shell wildcard expansion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "test": "teenytest",
     "style": "standard --fix",
-    "test:esm": "node --loader=quibble ./test/esm-lib/teenytest-proxy.js ./test/esm-lib/*.test.{mjs,js}",
-    "test:no-loader-esm": "teenytest ./test/esm-lib/*.no-loader-test.js && teenytest ./test/esm-lib/*.no-loader-test.mjs",
+    "test:esm": "node --loader=quibble ./test/esm-lib/teenytest-proxy.js \"./test/esm-lib/*.test.{mjs,js}\"",
+    "test:no-loader-esm": "teenytest \"./test/esm-lib/*.no-loader-test.js\" && teenytest \"./test/esm-lib/*.no-loader-test.mjs\"",
     "test:example": "cd example && npm it",
     "test:example-esm": "cd example-esm && npm it",
     "test:smells": "bash ./test/require-smell-test.sh",


### PR DESCRIPTION
1. Add a change to set linends to lf on all platforms.
2. ci: escape wildcards to avoid shell expansion
  Single quotes did not work properly in Windows.  No quotes and double quotes work in Windows but no quotes do not work off Windows.  Hoping double quotes work on all platforms.
  