### PR TITLE
Support node 20

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/example-esm/package-lock.json
+++ b/example-esm/package-lock.json
@@ -11,6 +11,26 @@
         "quibble": "file:.."
       }
     },
+    "..": {
+      "version": "0.6.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.22.1"
+      },
+      "devDependencies": {
+        "core-assert": "^1.0.0",
+        "is-number": "^7.0.0",
+        "is-promise": "^4.0.0",
+        "standard": "^17.0.0",
+        "teenytest": "^6.0.4",
+        "teenytest-promise": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.14.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -383,12 +403,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -461,18 +475,6 @@
         "node": "*"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -517,18 +519,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -617,12 +607,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -785,12 +769,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -813,17 +791,8 @@
       }
     },
     "node_modules/quibble": {
-      "version": "0.6.15",
-      "resolved": "file:..",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "node": ">= 0.14.0"
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -853,23 +822,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safe-buffer": {
@@ -952,18 +904,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-regex-range": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,6 +11,26 @@
         "quibble": "file:.."
       }
     },
+    "..": {
+      "version": "0.6.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.22.1"
+      },
+      "devDependencies": {
+        "core-assert": "^1.0.0",
+        "is-number": "^7.0.0",
+        "is-promise": "^4.0.0",
+        "standard": "^17.0.0",
+        "teenytest": "^6.0.4",
+        "teenytest-promise": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.14.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -383,12 +403,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -461,18 +475,6 @@
         "node": "*"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -517,18 +519,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -617,12 +607,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -785,12 +769,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -813,17 +791,8 @@
       }
     },
     "node_modules/quibble": {
-      "version": "0.6.15",
-      "resolved": "file:..",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "node": ">= 0.14.0"
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -853,23 +822,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safe-buffer": {
@@ -952,18 +904,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-regex-range": {
@@ -1350,12 +1290,6 @@
       "dev": true,
       "optional": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1412,15 +1346,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1456,15 +1381,6 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
       }
     },
     "is-extglob": {
@@ -1523,12 +1439,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -1644,12 +1554,6 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -1663,11 +1567,16 @@
       "dev": true
     },
     "quibble": {
-      "version": "0.6.15",
-      "dev": true,
+      "version": "file:..",
       "requires": {
+        "core-assert": "^1.0.0",
+        "is-number": "^7.0.0",
+        "is-promise": "^4.0.0",
         "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
+        "resolve": "^1.22.1",
+        "standard": "^17.0.0",
+        "teenytest": "^6.0.4",
+        "teenytest-promise": "^1.0.0"
       }
     },
     "randombytes": {
@@ -1693,17 +1602,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
-    },
-    "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -1754,12 +1652,6 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/lib/esm-import-functions.js
+++ b/lib/esm-import-functions.js
@@ -1,18 +1,14 @@
 const path = require('path')
-// These functions are in a separate file due to the fact that we need to support Node.js v8, which
-// cannot parse the `import` syntax.
-// The way it is dealt with is that we require this module only in code paths in `quibble.js`
-// that are ESM related.
+const { pathToFileURL } = require('url')
 
 exports.dummyImportModuleToGetAtPath = async function dummyImportModuleToGetAtPath (modulePath) {
   try {
-    if (path.isAbsolute(modulePath)) {
-      modulePath = 'file://' + modulePath
-    }
-    await import(modulePath + (modulePath.includes('?') ? '&' : '?') + '__quibbleresolvepath')
+    const moduleUrl = path.isAbsolute(modulePath) ? pathToFileURL(modulePath) : modulePath
+
+    await import(addQueryToUrl(moduleUrl, '__quibbleresolveurl'))
   } catch (error) {
-    if (error.code === 'QUIBBLE_RESOLVED_PATH') {
-      return error.resolvedPath
+    if (error.code === 'QUIBBLE_RESOLVED_URL') {
+      return error.resolvedUrl
     } else {
       throw error
     }
@@ -24,8 +20,15 @@ exports.dummyImportModuleToGetAtPath = async function dummyImportModuleToGetAtPa
 }
 
 exports.importOriginalModule = async (fullImportPath) => {
-  if (path.isAbsolute(fullImportPath)) {
-    fullImportPath = 'file://' + fullImportPath
+  return import(addQueryToUrl(fullImportPath, '__quibbleoriginal'))
+}
+
+function addQueryToUrl (url, query) {
+  try {
+    const urlObject = new URL(url)
+    urlObject.searchParams.set(query, '')
+    return urlObject.href.replace(`${query}=`, query)
+  } catch {
+    return url + '?' + query
   }
-  return import(fullImportPath + '?__quibbleoriginal')
 }

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -1,8 +1,9 @@
 const Module = require('module')
 const path = require('path')
 const util = require('util')
-const { URL } = require('url')
+const { URL, pathToFileURL, fileURLToPath } = require('url')
 const resolve = require('resolve')
+const importFunctions = require('./esm-import-functions')
 const isPlainObject = require('lodash/isPlainObject.js')
 const _ = {
   compact: require('lodash/fp/compact'),
@@ -20,13 +21,14 @@ const _ = {
   tap: require('lodash/tap'),
   values: require('lodash/values')
 }
-let importFunctionsModule
 
 const originalLoad = Module._load
 let config = null
 let quibbles = {}
 let ignoredCallerFiles = []
 let quibble
+
+const quibbleUserToLoaderCommunication = () => globalThis[Symbol.for('__quibbleUserToLoaderCommunication')]
 
 module.exports = quibble = function (request, stub) {
   request = quibble.absolutify(request)
@@ -51,16 +53,14 @@ quibble.ignoreCallsFromThisFile = function (file) {
   if (file == null) {
     file = hackErrorStackToGetCallerFile(false)
   }
-  ignoredCallerFiles = _.uniq(ignoredCallerFiles.concat(file))
+  ignoredCallerFiles = _.uniq(ignoredCallerFiles.concat(file, pathToFileURL(file).href))
 }
 
 quibble.reset = function (hard) {
   Module._load = originalLoad
   quibbles = {}
 
-  if (global.__quibble) {
-    delete global.__quibble.quibbledModules
-  }
+  quibbleUserToLoaderCommunication()?.reset()
 
   config = quibble.config()
   if (hard) {
@@ -77,9 +77,8 @@ quibble.absolutify = function (relativePath, parentFileName) {
   return resolvedPath || absolutePath
 }
 
-quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
+quibble.esm = async function (specifier, namedExportStubs, defaultExportStub) {
   checkThatLoaderIsLoaded()
-
   if (namedExportStubs != null && !util.types.isProxy(namedExportStubs) && !isPlainObject(namedExportStubs)) {
     throw new Error('namedExportsStub argument must be either a plain object or null/undefined')
   }
@@ -95,67 +94,38 @@ quibble.esm = async function (importPath, namedExportStubs, defaultExportStub) {
     delete finalNamedExportStubs.default
   }
 
-  if (!global.__quibble.quibbledModules) {
-    global.__quibble.quibbledModules = new Map()
-  }
-  ++global.__quibble.stubModuleGeneration
-  importFunctionsModule = importFunctionsModule || require('./esm-import-functions')
+  const importPathIsBareSpecifier = isBareSpecifier(specifier)
+  const parentUrl = importPathIsBareSpecifier ? undefined : hackErrorStackToGetCallerFile(true, true)
+  const moduleUrl = importPathIsBareSpecifier
+    ? await importFunctions.dummyImportModuleToGetAtPath(specifier)
+    : new URL(specifier, parentUrl).href
 
-  const importPathIsBareSpecifier = isBareSpecifier(importPath)
-  const isAbsolutePath = path.isAbsolute(importPath)
-
-  let callerFile
-  if (!isAbsolutePath && !importPathIsBareSpecifier) {
-    callerFile = hackErrorStackToGetCallerFile()
-    if (process.platform === 'win32' && callerFile[0] === '/') {
-      callerFile = callerFile.substring(1)
-    }
-  }
-
-  const modulePath = importPathIsBareSpecifier
-    ? await importFunctionsModule.dummyImportModuleToGetAtPath(importPath)
-    : isAbsolutePath
-      ? importPath
-      : (path.resolve(path.dirname(callerFile), importPath))
-  const fullModulePath = process.platform !== 'win32' ? modulePath : (modulePath.match(/^[a-zA-Z]:/) ? '/' : '') + modulePath.split(path.sep).join('/')
-
-  global.__quibble.quibbledModules.set(fullModulePath, {
-    defaultExportStub,
-    namedExportStubs: finalNamedExportStubs
+  await quibbleUserToLoaderCommunication().addMockedModule(moduleUrl, {
+    namedExportStubs: finalNamedExportStubs,
+    defaultExportStub
   })
 }
 
 quibble.isLoaderLoaded = function () {
-  return !!global.__quibble
+  return !!quibbleUserToLoaderCommunication()
 }
 
-quibble.esmImportWithPath = async function esmImportWithPath (importPath) {
+quibble.esmImportWithPath = async function esmImportWithPath (specifier) {
   checkThatLoaderIsLoaded()
 
-  importFunctionsModule = importFunctionsModule || require('./esm-import-functions')
-
-  const importPathIsBareSpecifier = isBareSpecifier(importPath)
-  const isAbsolutePath = path.isAbsolute(importPath)
-  let callerFile
-  if (!isAbsolutePath && !importPathIsBareSpecifier) {
-    callerFile = hackErrorStackToGetCallerFile()
-    if (process.platform === 'win32' && callerFile[0] === '/') {
-      callerFile = callerFile.substring(1)
-    }
-  }
-
-  const modulePath = importPathIsBareSpecifier
-    ? await importFunctionsModule.dummyImportModuleToGetAtPath(importPath)
-    : isAbsolutePath
-      ? importPath
-      : (path.resolve(path.dirname(callerFile), importPath))
-  const fullImportPath = importPathIsBareSpecifier
-    ? importPath
-    : (process.platform !== 'win32' ? modulePath : (modulePath.match(/^[a-zA-Z]:/) ? '/' : '') + modulePath.split(path.sep).join('/'))
+  const importPathIsBareSpecifier = isBareSpecifier(specifier)
+  const parentUrl = importPathIsBareSpecifier ? undefined : hackErrorStackToGetCallerFile(true, true)
+  const moduleUrl = importPathIsBareSpecifier
+    ? await importFunctions.dummyImportModuleToGetAtPath(specifier)
+    : new URL(specifier, parentUrl).href
 
   return {
-    modulePath,
-    module: await importFunctionsModule.importOriginalModule(fullImportPath)
+    // The name of this property _should_ be `moduleUrl`, but it is used in `testdouble` as `modulePath`
+    // and so can't be changed without breaking `testdouble`. So I add another field with the correct name
+    // and once testdouble is updated, I can remove the `modulePath` field.
+    modulePath: moduleUrl,
+    moduleUrl,
+    module: await importFunctions.importOriginalModule(moduleUrl)
   }
 }
 
@@ -228,10 +198,7 @@ const nodeResolve = function (request, options) {
   } catch (e) {}
 }
 
-const hackErrorStackToGetCallerFile = function (includeGlobalIgnores) {
-  if (includeGlobalIgnores == null) {
-    includeGlobalIgnores = true
-  }
+const hackErrorStackToGetCallerFile = function (includeGlobalIgnores = true, keepUrls = false) {
   const originalFunc = Error.prepareStackTrace
   const originalStackTraceLimit = Error.stackTraceLimit
   try {
@@ -239,16 +206,18 @@ const hackErrorStackToGetCallerFile = function (includeGlobalIgnores) {
     Error.prepareStackTrace = function (e, stack) {
       return stack
     }
+    const conversionFunc = keepUrls ? convertStackPathToUrl : convertStackUrlToPath
     const e = new Error()
-    const currentFile = convertUrlToPath(e.stack[0].getFileName())
+    const currentFile = conversionFunc(e.stack[0].getFileName())
     return _.flow([
       _.invokeMap('getFileName'),
       _.compact,
-      _.map(convertUrlToPath),
+      _.map(conversionFunc),
       _.reject(function (f) {
         return includeGlobalIgnores && _.includes(f, ignoredCallerFiles)
       }),
-      _.filter(path.isAbsolute),
+      _.filter(keepUrls ? _.identity : path.isAbsolute),
+      _.filter(conversionFunc),
       _.find(function (f) {
         return f !== currentFile
       })
@@ -260,21 +229,28 @@ const hackErrorStackToGetCallerFile = function (includeGlobalIgnores) {
 }
 
 function checkThatLoaderIsLoaded () {
-  if (!global.__quibble) {
+  if (!quibble.isLoaderLoaded()) {
     throw new Error('quibble loader not loaded. You cannot replace ES modules without a loader. Run node with `--loader=quibble`.')
   }
 }
 
-function convertUrlToPath (fileUrl) {
+function convertStackUrlToPath (fileUrl) {
   try {
-    const p = fileUrl.match(/^[a-zA-Z]:/) ? fileUrl : new URL(fileUrl).pathname
-    return p
+    return fileURLToPath(fileUrl)
   } catch (error) {
-    if (error.code === 'ERR_INVALID_URL') {
+    if (error.code !== 'TYPE_ERROR') {
       return fileUrl
     } else {
       throw error
     }
+  }
+}
+
+function convertStackPathToUrl (filePath) {
+  if (path.isAbsolute(filePath)) {
+    return pathToFileURL(filePath).href
+  } else {
+    return filePath
   }
 }
 

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -14,10 +14,6 @@ export function globalPreload () {
   return `(${loadQuibble.toString()})()`
 }
 
-export function getGlobalPreloadCode () {
-  return `(${loadQuibble.toString()})()`
-}
-
 export async function resolve (specifier, context, nextResolve) {
   const resolve = () => nextResolve(
     specifier.includes('__quibble')
@@ -68,24 +64,6 @@ export async function resolve (specifier, context, nextResolve) {
       }
     } else { throw error }
   }
-}
-
-export async function getFormat (url, context, defaultGetFormat) {
-  if (getStubsInfo(new URL(url))) {
-    return {
-      format: 'module'
-    }
-  } else {
-    return defaultGetFormat(url, context, defaultGetFormat)
-  }
-}
-
-export async function getSource (url, context, defaultGetSource) {
-  const stubsInfo = getStubsInfo(new URL(url))
-
-  return stubsInfo
-    ? { source: transformModuleSource(stubsInfo) }
-    : defaultGetSource(url, context, defaultGetSource)
 }
 
 /** @param {URL} moduleUrl */

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -6,31 +6,39 @@ export const ignoreCallsFromThisFile = quibble.ignoreCallsFromThisFile
 export const config = quibble.config
 export const isLoaderLoaded = quibble.isLoaderLoaded
 
-function loadQuibble () {
-  global.__quibble = { stubModuleGeneration: 1 }
-}
-
-export function globalPreload () {
-  return `(${loadQuibble.toString()})()`
+/** @typedef {{hasDefaultExportStub: boolean, namedExports: [string]}} ModuleLoaderMockInfo */
+/**
+ * @type {{
+ *  quibbledModules: Map<string, ModuleLoaderMockInfo>,
+ *  stubModuleGeneration: number
+ * }}
+ *
+ */
+const quibbleLoaderState = {
+  quibbledModules: new Map(),
+  stubModuleGeneration: 0
 }
 
 export async function resolve (specifier, context, nextResolve) {
-  const resolve = () => nextResolve(
-    specifier.includes('__quibble')
-      ? specifier.replace('?__quibbleresolvepath', '').replace('?__quibbleoriginal', '')
-      : (specifier.match(/^[a-zA-Z]:/) ? `file://${specifier}` : specifier),
-    context
-  )
+  const resolve = () =>
+    nextResolve(
+      specifier.includes('__quibble')
+        ? specifier
+          .replace(/[?&]__quibbleresolveurl/, '')
+          .replace(/[?&]__quibbleoriginal/, '')
+        : specifier,
+      context
+    )
 
-  if (specifier.includes('__quibbleresolvepath')) {
-    const resolvedPath = new URL((await resolve()).url).pathname
+  if (specifier.includes('__quibbleresolveurl')) {
+    const resolvedUrl = (await resolve()).url
     const error = new Error()
-    error.code = 'QUIBBLE_RESOLVED_PATH'
-    error.resolvedPath = resolvedPath
+    error.code = 'QUIBBLE_RESOLVED_URL'
+    error.resolvedUrl = resolvedUrl
     throw error
   }
 
-  if (!global.__quibble.quibbledModules) {
+  if (!quibbleLoaderState.quibbledModules) {
     return resolve()
   }
 
@@ -38,58 +46,74 @@ export async function resolve (specifier, context, nextResolve) {
     return resolve()
   }
 
-  const stubModuleGeneration = global.__quibble.stubModuleGeneration
-
   if (specifier.includes('__quibbleoriginal')) {
     return resolve()
   }
 
+  const stubModuleGeneration = quibbleLoaderState.stubModuleGeneration
   const { parentURL } = context
 
   try {
     const { url } = await resolve()
 
-    const quibbledUrl = `${url}?__quibble=${stubModuleGeneration}`
+    const quibbledUrl = addQueryToUrl(url, '__quibble', stubModuleGeneration)
 
-    // 'node:' is the prefix for Node >=14.13. 'nodejs:' is for earlier versions
-    if (/^node(js){0,1}:/.test(url) && !getStubsInfo(new URL(quibbledUrl))) return { url }
+    if (url.startsWith('node:') && !getStubsInfo(quibbledUrl)) {
+      return { url }
+    }
 
     return { url: quibbledUrl }
   } catch (error) {
     if (error.code === 'ERR_MODULE_NOT_FOUND') {
       return {
         url: parentURL
-          ? `${new URL(specifier, parentURL).href}?__quibble=${stubModuleGeneration}`
+          ? addQueryToUrl(
+            new URL(specifier, parentURL).href
+            , '__quibble', stubModuleGeneration)
           : new URL(specifier).href
       }
-    } else { throw error }
+    } else {
+      throw error
+    }
   }
 }
 
-/** @param {URL} moduleUrl */
+/**
+ * @param {string} moduleUrl
+ *
+ * @returns {[string, ModuleLoaderMockInfo] | undefined}
+ * */
 function getStubsInfo (moduleUrl) {
-  if (!global.__quibble.quibbledModules) return undefined
-  if (!moduleUrl.searchParams.get('__quibble')) return undefined
+  if (!quibbleLoaderState.quibbledModules) return undefined
+  if (!moduleUrl.includes('__quibble=')) return undefined
 
-  const moduleFilepath = moduleUrl.pathname
+  const moduleKey = moduleUrl
+    .replace(/\?.*/, '')
+    .replace(/#.*/, '')
 
-  const stub = global.__quibble.quibbledModules.get(moduleFilepath)
-  return stub ? [moduleFilepath, stub] : undefined
+  const moduleMockingInfo = quibbleLoaderState.quibbledModules.get(moduleKey)
+
+  return moduleMockingInfo ? [moduleKey, moduleMockingInfo] : undefined
 }
 
-function transformModuleSource ([moduleKey, stubs]) {
+/**
+ *
+ * @param {[string, ModuleLoaderMockInfo]} options
+ * @returns
+ */
+function transformModuleSource ([moduleKey, mockingInfo]) {
   return `
-${Object.keys(stubs.namedExportStubs || {})
+${mockingInfo.namedExports
   .map(
     (name) =>
-      `export let ${name} = global.__quibble.quibbledModules.get(${JSON.stringify(
+      `export let ${name} = globalThis[Symbol.for('__quibbleUserState')].quibbledModules.get(${JSON.stringify(
         moduleKey
       )}).namedExportStubs["${name}"]`
   )
   .join(';\n')};
 ${
-  stubs.defaultExportStub
-    ? `export default global.__quibble.quibbledModules.get(${JSON.stringify(
+  mockingInfo.hasDefaultExport
+    ? `export default globalThis[Symbol.for('__quibbleUserState')].quibbledModules.get(${JSON.stringify(
         moduleKey
       )}).defaultExportStub;`
     : ''
@@ -106,9 +130,98 @@ ${
  * @returns {Promise<{ source: !(string | SharedArrayBuffer | Uint8Array), format: string}>}
  */
 export async function load (url, context, nextLoad) {
-  const stubsInfo = getStubsInfo(new URL(url))
+  const mockingInfo = getStubsInfo(url)
 
-  return stubsInfo
-    ? { source: transformModuleSource(stubsInfo), format: 'module', shortCircuit: true }
-    : nextLoad(url, context)
+  return mockingInfo
+    ? {
+        source: transformModuleSource(mockingInfo),
+        format: 'module',
+        shortCircuit: true
+      }
+    : await nextLoad(url.replace(/\?.*/, '').replace(/#.*/, ''), context)
+}
+
+export const globalPreload = ({ port }) => {
+  globalThis[Symbol.for('__quibbleLoaderState')] = quibbleLoaderState
+
+  port.addEventListener('message', ({ data }) => {
+    if (data.type === 'reset') {
+      quibbleLoaderState.quibbledModules = new Map()
+      quibbleLoaderState.stubModuleGeneration++
+      Atomics.store(data.hasResetHappened, 0, 1)
+      Atomics.notify(data.hasResetHappened, 0)
+    } else if (data.type === 'addMockedModule') {
+      quibbleLoaderState.quibbledModules.set(data.moduleUrl, {
+        namedExports: data.namedExports,
+        hasDefaultExport: data.hasDefaultExport
+      })
+      ++quibbleLoaderState.stubModuleGeneration
+      Atomics.store(data.hasAddMockedHappened, 0, 1)
+      Atomics.notify(data.hasAddMockedHappened, 0)
+    }
+  })
+  port.unref()
+
+  return `(${thisWillRunInUserThread})(globalThis, port)`
+}
+
+async function thisWillRunInUserThread (globalThis, port) {
+  globalThis[Symbol.for('__quibbleUserState')] = { quibbledModules: new Map() }
+
+  globalThis[Symbol.for('__quibbleUserToLoaderCommunication')] = {
+    reset () {
+      globalThis[Symbol.for('__quibbleUserState')].quibbledModules = new Map()
+
+      if (!loaderAndUserRunInSameThread(globalThis)) {
+        const hasResetHappened = new Int32Array(new SharedArrayBuffer(4))
+        port.postMessage({ type: 'reset', hasResetHappened })
+        Atomics.wait(hasResetHappened, 0, 0)
+      } else {
+        const quibbleLoaderState = globalThis[Symbol.for('__quibbleLoaderState')]
+
+        quibbleLoaderState.quibbledModules = new Map()
+        quibbleLoaderState.stubModuleGeneration++
+      }
+    },
+    async addMockedModule (
+      moduleUrl,
+      { namedExportStubs, defaultExportStub }
+    ) {
+      globalThis[Symbol.for('__quibbleUserState')].quibbledModules.set(moduleUrl, {
+        defaultExportStub,
+        namedExportStubs
+      })
+
+      if (!loaderAndUserRunInSameThread(globalThis)) {
+        const hasAddMockedHappened = new Int32Array(new SharedArrayBuffer(4))
+
+        port.postMessage({
+          type: 'addMockedModule',
+          moduleUrl,
+          namedExports: Object.keys(namedExportStubs || []),
+          hasDefaultExport: defaultExportStub != null,
+          hasAddMockedHappened
+        })
+        Atomics.wait(hasAddMockedHappened, 0, 0)
+      } else {
+        const quibbleLoaderState = globalThis[Symbol.for('__quibbleLoaderState')]
+
+        quibbleLoaderState.quibbledModules.set(moduleUrl, {
+          hasDefaultExport: defaultExportStub != null,
+          namedExports: Object.keys(namedExportStubs || [])
+        })
+        ++quibbleLoaderState.stubModuleGeneration
+      }
+    }
+  }
+
+  function loaderAndUserRunInSameThread (globalThis) {
+    return !!globalThis[Symbol.for('__quibbleLoaderState')]
+  }
+}
+
+function addQueryToUrl (url, query, value) {
+  const urlObject = new URL(url)
+  urlObject.searchParams.set(query, value)
+  return urlObject.href
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "require": "./lib/quibble.js",
       "import": "./lib/quibble.mjs"
     },
-    "./": "./"
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "teenytest",

--- a/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
+++ b/test/esm-lib/quibble-cjs-esmImportWithPath.test.js
@@ -1,12 +1,14 @@
 const path = require('path')
+const { pathToFileURL } = require('url')
 const quibble = require('quibble')
 
 module.exports = {
   afterEach: function () { quibble.reset() },
   'support importing esm and returning the path for a relative url': async function () {
-    const { modulePath, module } = await quibble.esmImportWithPath('../esm-fixtures/a-module.mjs')
+    const { modulePath, moduleUrl, module } = await quibble.esmImportWithPath('../esm-fixtures/a-module.mjs')
 
-    assert.deepEqual(modulePath, path.resolve(__dirname, '../esm-fixtures/a-module.mjs'))
+    assert.deepEqual(modulePath, pathToFileURL(path.resolve(__dirname, '../esm-fixtures/a-module.mjs')).href)
+    assert.deepEqual(moduleUrl, pathToFileURL(path.resolve(__dirname, '../esm-fixtures/a-module.mjs')).href)
     assert.deepEqual({ ...module }, {
       default: 'default-export',
       namedExport: 'named-export',
@@ -19,7 +21,7 @@ module.exports = {
     // can always create a module of your own and put it in node_modules.
     const { modulePath, module } = await quibble.esmImportWithPath('is-promise')
 
-    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs').replace(/\\/g, '/').replace(/^([a-zA-Z]:)/, '/$1'))
+    assert.deepEqual(modulePath, pathToFileURL(require.resolve('is-promise')).href.replace('.js', '.mjs'))
     const { default: isPromise, ...rest } = module
     assert.deepEqual(rest, {})
     assert.deepEqual(isPromise(Promise.resolve()), true)
@@ -33,7 +35,7 @@ module.exports = {
     }, 'default-export-replacement')
     const { modulePath, module } = await quibble.esmImportWithPath('../esm-fixtures/a-module.mjs')
 
-    assert.deepEqual(modulePath, path.resolve(__dirname, '../esm-fixtures/a-module.mjs'))
+    assert.deepEqual(modulePath, pathToFileURL(path.resolve(__dirname, '../esm-fixtures/a-module.mjs')).href)
     assert.deepEqual({ ...module }, {
       default: 'default-export',
       namedExport: 'named-export',
@@ -47,7 +49,7 @@ module.exports = {
     await quibble.esm('is-promise', undefined, 42)
     const { modulePath, module } = await quibble.esmImportWithPath('is-promise')
 
-    assert.deepEqual(modulePath, require.resolve('is-promise').replace('.js', '.mjs').replace(/\\/g, '/').replace(/^([a-zA-Z]:)/, '/$1'))
+    assert.deepEqual(modulePath, pathToFileURL(require.resolve('is-promise')).href.replace('.js', '.mjs'))
     const { default: isPromise, ...rest } = module
     assert.deepEqual(rest, {})
     assert.deepEqual(isPromise(Promise.resolve()), true)

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -15,7 +15,6 @@ export default {
     // This import is important, as it checks how quibble interacts with internal modules
     await import('util')
 
-    console.log('3')
     const result = await import('../esm-fixtures/a-module-with-function.mjs')
     console.log('4')
     assert.equal(result.default, 'default-export-replacement')

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -12,10 +12,13 @@ export default {
       namedFunctionExport: () => 'export replacement'
     }, 'default-export-replacement')
 
+    console.log('2')
     // This import is important, as it checks how quibble interacts with internal modules
     await import('util')
 
+    console.log('3')
     const result = await import('../esm-fixtures/a-module-with-function.mjs')
+    console.log('4')
     assert.equal(result.default, 'default-export-replacement')
     assert.equal(result.namedExport, 'replacement')
     assert.equal(result.life, 41)

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -12,7 +12,6 @@ export default {
       namedFunctionExport: () => 'export replacement'
     }, 'default-export-replacement')
 
-    console.log('2')
     // This import is important, as it checks how quibble interacts with internal modules
     await import('util')
 

--- a/test/esm-lib/quibble-esm.test.mjs
+++ b/test/esm-lib/quibble-esm.test.mjs
@@ -16,7 +16,6 @@ export default {
     await import('util')
 
     const result = await import('../esm-fixtures/a-module-with-function.mjs')
-    console.log('4')
     assert.equal(result.default, 'default-export-replacement')
     assert.equal(result.namedExport, 'replacement')
     assert.equal(result.life, 41)

--- a/test/supports-esm.js
+++ b/test/supports-esm.js
@@ -1,3 +1,0 @@
-if (parseInt(process.version.split('.')[0].slice(1), 10) <= 12) {
-  process.exit(1)
-}


### PR DESCRIPTION
Fixes #95

Node.js 20 moved the loaders off the main thread, to their own thread. Usually this is not a problem for loaders, but `quibble` has an API that communicates with the loader itself. In versions prior to 20, this communication was done using global variables, but since the loaders are in a separate worker/thread, then this is not possible (workers/threads do not share global variables)

The only option for communication is to use messages between the main thread and the worker threads. Luckily, the loader team gave loaders the ability to do just that.

This PR enables the loader API to communicate with the loader using messages, if the loaders are off thread, and reverts to the previous method (global variables) if the loaders are in the main thread.

I took the liberty of removing crud related to ESM loaders in past versions. Also, the Github action now checks the current versions of Node, which are 16, 18, and 20.

I have also cleaned up the code and made Windows support easier by making all ESM code use _URLs_ instead of file paths, because 1) that is the native language ESM speaks, 2) It is compatible with Windows, and 3) now that we can have HTTP (and other) urls as import specifiers, then we are not allowed to assume that the files are on disk! 