### PR TITLE
add listMockedModules

### DIFF
--- a/example-esm/package-lock.json
+++ b/example-esm/package-lock.json
@@ -12,7 +12,7 @@
       }
     },
     "..": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,7 +12,7 @@
       }
     },
     "..": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/lib/quibble.js
+++ b/lib/quibble.js
@@ -119,6 +119,13 @@ quibble.esm = async function (specifier, namedExportStubs, defaultExportStub) {
   })
 }
 
+quibble.listMockedModules = function () {
+  const esmMockedModules = quibbleUserToLoaderCommunication()?.listMockedModules() ?? []
+  const cjsMockedModules = Object.keys(quibbles).map((modulePath) => pathToFileURL(modulePath).href)
+
+  return esmMockedModules.concat(cjsMockedModules)
+}
+
 quibble.isLoaderLoaded = function () {
   return !!quibbleUserToLoaderCommunication()
 }

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -88,9 +88,7 @@ function getStubsInfo (moduleUrl) {
   if (!quibbleLoaderState.quibbledModules) return undefined
   if (!moduleUrl.includes('__quibble=')) return undefined
 
-  const moduleKey = moduleUrl
-    .replace(/\?.*/, '')
-    .replace(/#.*/, '')
+  const moduleKey = moduleUrl.replace(/\?.*/, '').replace(/#.*/, '')
 
   const moduleMockingInfo = quibbleLoaderState.quibbledModules.get(moduleKey)
 
@@ -159,6 +157,19 @@ export const globalPreload = ({ port }) => {
       ++quibbleLoaderState.stubModuleGeneration
       Atomics.store(data.hasAddMockedHappened, 0, 1)
       Atomics.notify(data.hasAddMockedHappened, 0)
+    } else if (data.type === 'listMockedModules') {
+      const mockedModules = Array.from(quibbleLoaderState.quibbledModules.keys())
+      const serializedMockedModules = mockedModules.join(' ')
+      const encodedMockedModules = new TextEncoder().encode(serializedMockedModules)
+
+      data.mockedModulesListLength[0] = encodedMockedModules.length
+      if (encodedMockedModules.length <= data.mockedModulesList.length) {
+        for (let i = 0; i < encodedMockedModules.length; ++i) {
+          data.mockedModulesList[i] = encodedMockedModules[i]
+        }
+      }
+      Atomics.store(data.hasListMockedModulesHappened, 0, 1)
+      Atomics.notify(data.hasListMockedModulesHappened, 0)
     }
   })
   port.unref()

--- a/lib/thisWillRunInUserThread.js
+++ b/lib/thisWillRunInUserThread.js
@@ -16,7 +16,7 @@ exports.thisWillRunInUserThread = (globalThis, port) => {
         quibbleLoaderState.stubModuleGeneration++
       }
     },
-    async addMockedModule (
+    addMockedModule (
       moduleUrl,
       { namedExportStubs, defaultExportStub }
     ) {
@@ -44,6 +44,29 @@ exports.thisWillRunInUserThread = (globalThis, port) => {
           namedExports: Object.keys(namedExportStubs || [])
         })
         ++quibbleLoaderState.stubModuleGeneration
+      }
+    },
+    listMockedModules () {
+      if (!loaderAndUserRunInSameThread(globalThis)) {
+        const hasListMockedModulesHappened = new Int32Array(new SharedArrayBuffer(4))
+        const mockedModulesListLength = new Int32Array(new SharedArrayBuffer(4))
+        const mockedModulesList = new Uint8Array(new SharedArrayBuffer(20 * 1024 * 1024)) // 20MB should be sufficient
+        port.postMessage({
+          type: 'listMockedModules',
+          hasListMockedModulesHappened,
+          mockedModulesListLength,
+          mockedModulesList
+        })
+        Atomics.wait(hasListMockedModulesHappened, 0, 0)
+        if (mockedModulesListLength[0] > mockedModulesList.length) {
+          throw new Error('Not enough buffer allocated for result')
+        }
+        const serializedMockedModules = new TextDecoder().decode(mockedModulesList.slice(0, mockedModulesListLength[0]))
+        return serializedMockedModules ? serializedMockedModules.split(' ') : []
+      } else {
+        const quibbleLoaderState = globalThis[Symbol.for('__quibbleLoaderState')]
+
+        return Array.from(quibbleLoaderState.quibbledModules.keys())
       }
     }
   }

--- a/test/lib/quibble.test.js
+++ b/test/lib/quibble.test.js
@@ -1,4 +1,5 @@
 const quibble = require('../../lib/quibble')
+const { pathToFileURL } = require('url')
 
 module.exports = {
   'basic behavior': function () {
@@ -126,6 +127,24 @@ module.exports = {
     const quibbledRequiresANodeModule = require('../fixtures/requires-a-node-module')
 
     assert.equal(quibbledRequiresANodeModule(), false)
+  },
+  'list mocked modules': async function () {
+    quibble('../fixtures/a-function', function () { return 'kek' })
+
+    assert.deepEqual(quibble.listMockedModules(), [
+      pathToFileURL(quibble.absolutify('../fixtures/a-function', __filename)).href
+    ])
+
+    quibble('../fixtures/b-function', function () { return 'kek' })
+
+    assert.deepEqual(quibble.listMockedModules(), [
+      pathToFileURL(quibble.absolutify('../fixtures/a-function', __filename)).href,
+      pathToFileURL(quibble.absolutify('../fixtures/b-function', __filename)).href
+    ])
+
+    quibble.reset()
+
+    assert.deepEqual(await quibble.listMockedModules(), [])
   },
   afterEach: function () {
     quibble.reset()


### PR DESCRIPTION
This was requested in order to (as a good use case) troubleshoot whether testdouble really did mock or not.

Returns both CJS and ESM mocked files. 

Note that it returns the full path of the mocked file, no matter what the specifier mocked was, and it returns them as `file:` URLs and not file paths. This is true for both CJS and ESM mocked files