### PR TITLE
Don't use Node.js version number to determine loader capabilities

### DIFF
--- a/example-esm/package-lock.json
+++ b/example-esm/package-lock.json
@@ -12,12 +12,12 @@
       }
     },
     "..": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
-        "resolve": "^1.22.4"
+        "resolve": "^1.22.8"
       },
       "devDependencies": {
         "core-assert": "^1.0.0",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,12 +12,12 @@
       }
     },
     "..": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
-        "resolve": "^1.22.4"
+        "resolve": "^1.22.8"
       },
       "devDependencies": {
         "core-assert": "^1.0.0",
@@ -1573,7 +1573,7 @@
         "is-number": "^7.0.0",
         "is-promise": "^4.0.0",
         "lodash": "^4.17.21",
-        "resolve": "^1.22.4",
+        "resolve": "^1.22.8",
         "standard": "^17.1.0",
         "teenytest": "^6.0.5",
         "teenytest-promise": "^1.0.0"

--- a/lib/canRegisterLoader.js
+++ b/lib/canRegisterLoader.js
@@ -1,9 +1,7 @@
-function canRegisterLoader () {
-  const [major, minor] = process.versions.node
-    .split('.')
-    .map((m) => parseInt(m, 10))
+const Module = require('module')
 
-  return major > 20 || (major === 20 && minor >= 6)
+function canRegisterLoader () {
+  return !!Module.register
 }
 
 exports.canRegisterLoader = canRegisterLoader

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
-        "resolve": "^1.22.4"
+        "resolve": "^1.22.8"
       },
       "devDependencies": {
         "core-assert": "^1.0.0",
@@ -2434,9 +2434,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -4807,9 +4807,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "resolve": "^1.22.4"
+    "resolve": "^1.22.8"
   },
   "devDependencies": {
     "core-assert": "^1.0.0",


### PR DESCRIPTION
To deal with the fact that some version of 18 will support the 20 loader API (including `register` and out-of-main-thread execution), we need to remove checking the version of Node.js in all the quibble code so that it can adapt to the Node.js version no matter what.

It was easier than I thought since most of the work was done previously. I did have to do a small but easy change in `canRegisterLoader`.