### PR TITLE
Add test for transitively requiring a module that is already cached

### DIFF
--- a/test/fixtures/requires-a-reexported-function.js
+++ b/test/fixtures/requires-a-reexported-function.js
@@ -1,0 +1,5 @@
+const aFunction = require('./requires-and-exports-a-function')
+
+module.exports = function () {
+  return 'loaded ' + aFunction()
+}

--- a/test/fixtures/requires-and-exports-a-function.js
+++ b/test/fixtures/requires-and-exports-a-function.js
@@ -1,0 +1,3 @@
+const aFunction = require('./a-function')
+
+module.exports = () => aFunction();

--- a/test/lib/quibble.test.js
+++ b/test/lib/quibble.test.js
@@ -120,6 +120,17 @@ module.exports = {
       const result = quibbledRequiresAFunction()
 
       assert.equal(result, 'loaded a fake function')
+    },
+    'transitively requiring a module and then quibbling it': function () {
+      require('../fixtures/requires-a-reexported-function');
+      quibble('../fixtures/a-function', function () { return 'a very fake function' })
+      const quibbledRequiresAFunction = require('../fixtures/requires-a-reexported-function')
+
+      const result = quibbledRequiresAFunction()
+
+      quibble.reset()
+
+      assert.equal(result, 'loaded a very fake function')
     }
   },
   'requiring-a-node-module': function () {


### PR DESCRIPTION
Given a module A, which is required by B, which again is required by C, one would expect the following to work:

1. require module B
2. quibble module A
3. load module C

We would expect module C to reference B, which references the quibbled version of A. Instead, it references the original non-quibbled version.

This seems to happen because the loader, when processing C's `require('./B')`, sees that B itself is not quibbled, and therefore loads it normally.

And because B is already cached, and that version references the non-quibbled version of A, we pull in the non-quibbled A as well.

This commit just adds a (failing) test for the issue. I don't have a sufficient understanding of quibble's internals to try to write a fix as well.