### PR TITLE
fix: loader stomping context from other loaders

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -55,15 +55,15 @@ export async function resolve (specifier, context, nextResolve) {
   const { parentURL } = context
 
   try {
-    const { url } = await resolve()
+    const { url, ...ctx } = await resolve()
 
     const quibbledUrl = addQueryToUrl(url, '__quibble', stubModuleGeneration)
 
     if (url.startsWith('node:') && !getStubsInfo(quibbledUrl)) {
-      return { url }
+      return { ...ctx, url } // It's allowed to change ctx for a builtin (but unlikely)
     }
 
-    return { url: quibbledUrl }
+    return { ...ctx, url: quibbledUrl }
   } catch (error) {
     if (error.code === 'ERR_MODULE_NOT_FOUND') {
       return {


### PR DESCRIPTION
Fixes https://github.com/testdouble/testdouble.js/issues/525
Fixes https://github.com/testdouble/testdouble.js/issues/528