### PR TITLE
fix: correct check for existing replacements

### DIFF
--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -39,7 +39,7 @@ export async function resolve (specifier, context, nextResolve) {
     throw error
   }
 
-  if (!quibbleLoaderState.quibbledModules) {
+  if (!quibbleLoaderState.quibbledModules.size) {
     return resolve()
   }
 


### PR DESCRIPTION
Fixes https://github.com/testdouble/testdouble.js/issues/528