### PR TITLE
Fix: Resolve 3rd party esm without quibbledUrl

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/lib/quibble.mjs
+++ b/lib/quibble.mjs
@@ -59,7 +59,7 @@ export async function resolve (specifier, context, nextResolve) {
 
     const quibbledUrl = addQueryToUrl(url, '__quibble', stubModuleGeneration)
 
-    if (url.startsWith('node:') && !getStubsInfo(quibbledUrl)) {
+    if ((url.startsWith('node:') || url.includes('node_modules')) && !getStubsInfo(quibbledUrl)) {
       return { ...ctx, url } // It's allowed to change ctx for a builtin (but unlikely)
     }
 


### PR DESCRIPTION
In Node.js >= v21.0.0 quibble adds 3rd party libs with `?__quibble=0` suffix as key to the quibbled modules. When Node.js is resolving the real module quibble does not find the mock, because this url does not include `?__quibble=0`.

I think it's related to these API changes: https://github.com/testdouble/quibble/pull/96

This PR fixes this problem by  excluding urls with `node_modules` from being resolved with `quibbledUrl`.

Fixes: https://github.com/testdouble/testdouble.js/issues/530